### PR TITLE
Bump security.version from 4.0.3.RELEASE to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org</url>
   <properties>
 		<spring.version>4.2.1.RELEASE</spring.version>
-		<security.version>4.0.3.RELEASE</security.version>
+		<security.version>5.4.0</security.version>
 		<jdk.version>1.8</jdk.version>
 	</properties>
   <dependencies>


### PR DESCRIPTION
Bumps `security.version` from 4.0.3.RELEASE to 5.4.0.

Updates `spring-security-core` from 4.0.3.RELEASE to 5.4.0
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/4.0.3.RELEASE...5.4.0)

Updates `spring-security-web` from 4.0.3.RELEASE to 5.4.0
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/4.0.3.RELEASE...5.4.0)

Updates `spring-security-config` from 4.0.3.RELEASE to 5.4.0
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/4.0.3.RELEASE...5.4.0)

Signed-off-by: dependabot[bot] <support@github.com>