### PR TITLE
Bump spring.version from 4.2.1.RELEASE to 5.2.6.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <name>alavelli Maven Webapp</name>
   <url>http://maven.apache.org</url>
   <properties>
-		<spring.version>4.2.1.RELEASE</spring.version>
+		<spring.version>5.2.6.RELEASE</spring.version>
 		<security.version>4.0.3.RELEASE</security.version>
 		<jdk.version>1.8</jdk.version>
 	</properties>


### PR DESCRIPTION
Bumps `spring.version` from 4.2.1.RELEASE to 5.2.6.RELEASE.

Updates `spring-core` from 4.2.1.RELEASE to 5.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.2.1.RELEASE...v5.2.6.RELEASE)

Updates `spring-webmvc` from 4.2.1.RELEASE to 5.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.2.1.RELEASE...v5.2.6.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>